### PR TITLE
removed the warning by adding implicit conversion -- EDColor/UIColor+Hex...

### DIFF
--- a/EDColor/UIColor+Hex.m
+++ b/EDColor/UIColor+Hex.m
@@ -64,7 +64,7 @@
     switch (strlen(s)) {
         case 2:
             // xx
-            r = g = b = value;
+            r = g = b = (int)value;
             a = 255;
             break;
         case 3:


### PR DESCRIPTION
removed the warning by adding implicit conversion.
